### PR TITLE
feat: include preCommitRunHook in `self.lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,19 @@ to get the same result, if our package requires more files.
   [pre-commit-hoos.nix](https://github.com/cachix/pre-commit-hooks.nix)
   configuration.
 
+  - When `nixDir.lib.buildFlake` is called with with the `injectPreCommit`
+    parameter (defaults to `true`), the pre-commit hook is going to get injected
+    automatically in every entry of the `devShells` folder.
+
+    Another side-effect is that `self.lib.preCommitRunHook.$system` will to
+    contain the appropiate shell hook.
+
+
 ## FAQ
 
 ### Should I use this lib?
 
 If you are maintaining a project with nix flakes that has a big `flake.nix` file
-of (>500 LOC) or that involves several nix files, you may benefit from this
+(>500 LOC) or that involves several nix files, you may benefit from this
 library.
 

--- a/example/myproj/flake.lock
+++ b/example/myproj/flake.lock
@@ -24,14 +24,14 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1667033450,
-        "narHash": "sha256-JET28foJAvNm4Jtshl3rTUpHsIOn/FXFOfPcAyaqEwo=",
+        "lastModified": 1672903262,
+        "narHash": "sha256-bKMgm1k8/9npDggxuDQsCrVThV2BHtq2VDsNclik2d0=",
         "type": "git",
-        "url": "file:../../"
+        "url": "file:./../../"
       },
       "original": {
         "type": "git",
-        "url": "file:../../"
+        "url": "file:./../../"
       }
     },
     "nixpkgs": {

--- a/example/myproj/flake.nix
+++ b/example/myproj/flake.nix
@@ -1,12 +1,10 @@
 {
-  description = "go-capataz project's flake";
-
-  # nixConfig.bash-prompt-suffix = "(flake)";
+  description = "example flake for nixDir";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixDir = {
-      url = "git+file:../../";
+      url = "git+file:./../../";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/example/myproj/nix/pre-commit.nix
+++ b/example/myproj/nix/pre-commit.nix
@@ -1,0 +1,6 @@
+_system: inputs: {}: {
+  src = ../.;
+  hooks = {
+    alejandra.enable = true;
+  };
+}


### PR DESCRIPTION
### Context

In some situations, flake authors may want access to the generated run pre-commit hook (e.g. to run the script in a docker image). This PR allows flake authors to access the script from the `self` input.