### PR TITLE
refact: pre commit lib

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,33 @@
+---
+name: "pre-commit"
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.nix"
+
+  pull_request:
+    paths:
+      - "**/*.nix"
+
+concurrency:
+  group: pre-commit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: "checkout nixDir"
+        uses: actions/checkout@v3
+        with:
+          ssh-known-hosts: 'github.internal.digitalocean.com'
+
+      - name: "setup nix on the runner"
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |-
+            system-features = nixos-test benchmark big-parallel kvm
+
+      - name: "run pre-commit checks"
+        run: "nix develop -c pre-commit run --all-files"

--- a/example/myproj/.gitignore
+++ b/example/myproj/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+
+.devenv

--- a/example/myproj/flake.lock
+++ b/example/myproj/flake.lock
@@ -128,14 +128,14 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1673291758,
-        "narHash": "sha256-oetcz7JszM4jhz0VsIrJCYKyIzC3Fi4VEi3ss3Yb5gE=",
+        "lastModified": 1674780291,
+        "narHash": "sha256-/x01RHDaOcKwKHCM88e4npL9CtlemC0U5+MaRjtidQA=",
         "type": "git",
-        "url": "file:./../../"
+        "url": "file:../../"
       },
       "original": {
         "type": "git",
-        "url": "file:./../../"
+        "url": "file:../../"
       }
     },
     "nixpkgs": {

--- a/example/myproj/flake.nix
+++ b/example/myproj/flake.nix
@@ -8,7 +8,7 @@
 
   inputs = {
     nixDir = {
-      url = "git+file:./../../";
+      url = "git+file:../../";
     };
     nixpkgs.follows = "nixDir/nixpkgs";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         src = ./.;
         hooks = {
           alejandra.enable = true;
+          commitizen.enable = true;
         };
       };
     in {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,6 @@
       preCommitRun = pre-commit-hooks.lib.${system}.run {
         src = ./.;
         hooks = {
-          alejandra.enable = true;
           commitizen.enable = true;
         };
       };

--- a/lib.nix
+++ b/lib.nix
@@ -8,7 +8,8 @@ nixDirInputs: let
   }:
     if self ? overlays
     then
-      import nixpkgs {
+      import nixpkgs
+      {
         inherit system;
         overlays =
           builtins.attrValues
@@ -61,33 +62,39 @@ nixDirInputs: let
         ''
       else entry;
 
-    nixSubDirNames = builtins.foldl' (acc: subdir: let
-      files =
-        lib.attrNames
-        (lib.filterAttrs hasDefaultNix (builtins.readDir (checkDirFileConflict "${path}/${subdir}")));
-    in
-      if builtins.length files == 1
-      then acc ++ [subdir]
-      else acc) []
-    subDirNames;
+    nixSubDirNames =
+      builtins.foldl'
+      (acc: subdir: let
+        files =
+          lib.attrNames
+          (lib.filterAttrs hasDefaultNix (builtins.readDir (checkDirFileConflict "${path}/${subdir}")));
+      in
+        if builtins.length files == 1
+        then acc ++ [subdir]
+        else acc) []
+      subDirNames;
 
-    entries = builtins.foldl' (acc: entryName: let
-      # the key sometimes may be a directory name, other times it may be a
-      # .nix file name. Remove the .nix suffix to standarize.
-      key =
-        lib.removeSuffix ".nix" entryName;
-    in
-      acc
-      // {
-        "${key}" =
-          if importStrategy == "withCallPackage"
-          then callPackage (import "${path}/${entryName}" system inputs) {}
-          else if importStrategy == "withPkgs"
-          then import "${path}/${entryName}" system inputs pkgs
-          else if importStrategy == "withNoPkgs"
-          then import "${path}/${entryName}" system inputs
-          else builtins.abort "implementation error: invalid importStrategy ${importStrategy}";
-      }) {} (nixSubDirNames ++ nixFiles);
+    entries =
+      builtins.foldl'
+      (acc: entryName: let
+        # the key sometimes may be a directory name, other times it may be a
+        # .nix file name. Remove the .nix suffix to standarize.
+        key =
+          lib.removeSuffix ".nix" entryName;
+      in
+        acc
+        // {
+          "${key}" =
+            if importStrategy == "withCallPackage"
+            then callPackage (import "${path}/${entryName}" system inputs) {}
+            else if importStrategy == "withPkgs"
+            then import "${path}/${entryName}" system inputs pkgs
+            else if importStrategy == "withNoPkgs"
+            then import "${path}/${entryName}" system inputs
+            else builtins.abort "implementation error: invalid importStrategy ${importStrategy}";
+        })
+      {}
+      (nixSubDirNames ++ nixFiles);
   in
     entries;
   #
@@ -101,23 +108,28 @@ nixDirInputs: let
       builtins.attrNames
       (lib.filterAttrs (name: ty: ty == "directory") (builtins.readDir path));
 
-    nixSubDirNames = builtins.foldl' (acc: subdir: let
-      files =
-        lib.attrNames
-        (lib.filterAttrs hasDefaultNix (builtins.readDir "${path}/${subdir}"));
-    in
-      if builtins.length files == 1
-      then acc ++ [subdir]
-      else acc) []
-    subDirNames;
+    nixSubDirNames =
+      builtins.foldl'
+      (acc: subdir: let
+        files =
+          lib.attrNames
+          (lib.filterAttrs hasDefaultNix (builtins.readDir "${path}/${subdir}"));
+      in
+        if builtins.length files == 1
+        then acc ++ [subdir]
+        else acc) []
+      subDirNames;
 
-    entries = builtins.foldl' (acc: entryName:
-      acc
-      // {
-        "${entryName}" =
-          import "${path}/${entryName}" inputs;
-      }) {}
-    nixSubDirNames;
+    entries =
+      builtins.foldl'
+      (acc: entryName:
+        acc
+        // {
+          "${entryName}" =
+            import "${path}/${entryName}" inputs;
+        })
+      {}
+      nixSubDirNames;
   in
     entries;
 


### PR DESCRIPTION
### Context

Allow pre-commit to get installed to the `lib` attribute despite the fact that we use `devenv` files