### PR TITLE
feat: add support devenv modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ lets you get back to your business.
   - [The `packages` output](#the-packages-output)
   - [The `lib` output](#the-lib-output)
   - [The `overlays` output](#the-overlays-output)
-  - [The `nixosModules` output](#the-nixosmodules-output)
-  - [The `homeManagerModules` output](#the-homemanagermodules-output)
 - [Third-Party Integrations](#third-party-integrations)
   - [devenv.sh](#devenv)
   - [pre-commit-hooks](#pre-commit-hooks)
@@ -90,8 +88,8 @@ Following are the various conventions that you can use with `nixDir`
 
 ### The `packages` output
 
-To add new packages, add an entry in your `nix/packages` directory. The entry
-may be a nix file, or a directory with a `default.nix`. The name of the
+To add new packages, add an entry in your `nix/packages` directory. The package
+entry may be a nix file, or a directory with a `default.nix`. The name of the
 file/directory will be the name of the exported package. For example:
 
 ``` nix
@@ -201,9 +199,9 @@ packages across your flake. Following is an example:
       inherit inputs;
       systems = ["x86_64-linux"];
       root = ./.;
-      # We want the packages injected by the develop overlay
-      # available in our flake code.
-      injectOverlays = ["develop"];
+      # We want the packages injected by the `develop` overlay
+      # which is defined as an entry in our `nix/overlays.nix` file.
+      injectOverlays = [ "develop" ];
     };
 }
 ```
@@ -214,14 +212,6 @@ will be included in every `nixpkgs` import used within your flake exports.
 
 > :information_source: Given that flake overlays should be system agnostic, the
 > `nix/overlays.nix` file does not receive the `system` argument.
-
-### The `nixosModules` output
-
-TODO
-
-### The `homeManagerModules` output
-
-TODO
 
 ## Third-Party Integrations
 

--- a/example/myproj/flake.lock
+++ b/example/myproj/flake.lock
@@ -128,8 +128,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1674782057,
-        "narHash": "sha256-oTFmB1B7GTQSgwrarvC7S3f5j9A99fV+D7jUQmn6uR4=",
+        "lastModified": 1680724189,
+        "narHash": "sha256-DuqV9ZxTrUS/sD39UOv6VuyRIADE6K/QrnGGp+8rlpY=",
         "type": "git",
         "url": "file:../../"
       },

--- a/example/myproj/flake.nix
+++ b/example/myproj/flake.nix
@@ -15,9 +15,19 @@
 
   outputs = {nixDir, ...} @ inputs:
     nixDir.lib.buildFlake {
-      systems = ["x86_64-linux" "aarch64-darwin"];
-      root = ./.;
-      dirName = "nix";
+      # flake inputs, these inputs are propagated across all nix configuration
+      # managed by nixDir
       inputs = inputs;
+      # specify the systems that are supported
+      systems = ["x86_64-linux" "aarch64-darwin"];
+      # specify the directory that contains the nix directory.
+      root = ./.;
+      # specify the directory with our nix config is called nix. This is the
+      # default value, the declaration is here for demonstration purposes.
+      dirName = "nix";
+      # use a list of module names (e.g. nix/modules/devenv/my-hello-service) or
+      # a boolean value to signal we want all our devenv modules imported when
+      # we have an entry in the nix/devenvs directory.
+      injectDevenvModules = [ "my-hello-service" ];
     };
 }

--- a/example/myproj/nix/devenvs/devenv.nix
+++ b/example/myproj/nix/devenvs/devenv.nix
@@ -4,13 +4,23 @@ _system: _inputs: {
   ...
 }: {
   config = {
-    packages = [pkgs.hello];
+    packages = [ pkgs.cowsay ];
     languages.go.enable = true;
-    processes = {
-      silly-example.exec = "while true; do echo hello && sleep 1; done";
-    };
+
+    # use regular devenv functionality
     enterShell = ''
-      echo "enterShell worked"
+      cowsay "myproj demo"
     '';
+
+    # define a process in-line in the devenv configuration
+    processes = {
+      silly-example.exec = "while true; do echo silly-example && sleep 1; done";
+    };
+
+    # or use the settings defined in the nix/modules/devenv/my-hello-service
+    # directory.
+    #
+    # This can only work if the injectDevenvModules is defined
+    services.my-hello.enable = true;
   };
 }

--- a/example/myproj/nix/modules/devenv/my-hello-service/default.nix
+++ b/example/myproj/nix/modules/devenv/my-hello-service/default.nix
@@ -1,0 +1,21 @@
+system: inputs : { config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.my-hello;
+
+  startScript = pkgs.writeShellScriptBin "start-my-hello" ''
+    set -euo pipefail
+    while true; do ${pkgs.hello}/bin/hello -g "my-hello enabled" && sleep 1; done
+  '';
+in
+{
+  options = {
+    services.my-hello = {
+      enable = lib.mkEnableOption "My Hello World app";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    processes.my-hello.exec = ''${startScript}/bin/start-my-hello'';
+  };
+}


### PR DESCRIPTION
### Context

As a software developer that uses devenv
I want to be able to create re-usable devenv modules that I can export from my flake
So that all the configuration of my devenv environment doesn't live in the `nix/devenvs/default.nix`

This PR introduces support for a new path `nix/modules/devenv/` which automatically exports devenv modules from your flake, as well as allow you to inject these modules on your project's devenv shells as well.