### PR TITLE
feat: allow configuration and modules for various platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # nixDir
 
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[!Github Action Tests Status](https://github.com/roman/nixDir/actions/workflows/pre-commit.yml/badge.svg)
+
 `nixDir` is a library that transforms a convention oriented directory structure
 into a [nix flake](https://nixos.wiki/wiki/Flakes).
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ lets you get back to your business.
   - [The `packages` output](#the-packages-output)
   - [The `lib` output](#the-lib-output)
   - [The `overlays` output](#the-overlays-output)
+  - [Various modules outputs](#various-modules-outputs)
   - [Passthrough keys](#passthrough-keys)
 - [Third-Party Integrations](#third-party-integrations)
   - [devenv.sh](#devenv)
@@ -219,6 +220,25 @@ will be included in every `nixpkgs` import used within your flake exports.
 
 > :information_source: Given that flake overlays should be system agnostic, the
 > `nix/overlays.nix` file does not receive the `system` argument.
+
+### Various modules outputs
+
+The nix eco-system provides many different kinds of
+[modules](https://nixos.wiki/wiki/NixOS_modules). The module outputs currently
+supported by `nixDir` are:
+
+* `nixosModules` -- it allow authors to write modules supported by NixOS in the
+  `nix/modules/nixos` directory.
+
+* `darwinModules` -- it allow authors to write modules supported by
+  [`nix-darwin`](https://github.com/LnL7/nix-darwin) in the `nix/modules/darwin`
+  directory.
+
+* `homeManagerModules` -- it allow authors to write modules supported by
+  [`home-manager`](https://github.com/nix-community/home-manager) in the
+  `nix/modules/home-manager` directory.
+
+* `devenvModules` -- see [devenv](#devenvmodules-ouput) section for details
 
 
 ### Passthrough keys

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ lets you get back to your business.
   - [The `packages` output](#the-packages-output)
   - [The `lib` output](#the-lib-output)
   - [The `overlays` output](#the-overlays-output)
+  - [Passthrough keys](#passthrough-keys)
 - [Third-Party Integrations](#third-party-integrations)
   - [devenv.sh](#devenv)
   - [pre-commit-hooks](#pre-commit-hooks)
@@ -218,6 +219,45 @@ will be included in every `nixpkgs` import used within your flake exports.
 
 > :information_source: Given that flake overlays should be system agnostic, the
 > `nix/overlays.nix` file does not receive the `system` argument.
+
+
+### Passthrough keys
+
+Sometimes it makes sense to not have a dedicated file for the configuration of
+some flake outputs; the most common situation where authors usually want to
+declare a resource in-place is for `nixConfigurations`, `darwinConfigurations`
+and `homeManagerConfigurations`. Given they must be simple declarations, you can
+inline them into your `buildFlake` call. Following is an example:
+
+``` nix
+{
+
+  inputs = {
+    # ...
+  };
+
+  outputs = { nixDir, nixpkgs, nix-darwin, ... } @ inputs:
+    nixDir.lib.buildFlake {
+      systems = [ "x86_64-linux" "aarch64-darwin" ];
+
+      homeManagerConfigurations = {
+         # ... (your configuration here)
+      };
+
+      darwinConfigurations = {
+        myMacbook =  nix-darwin.lib.darwinSystem {
+          # ... (your configuration here)
+        };
+      };
+
+      nixosConfigurations = {
+        myLaptop = nixpkgs.lib.nixosSystem {
+          # ... (your configuration here)
+        };
+      };
+    };
+}
+```
 
 ## Third-Party Integrations
 

--- a/flake.lock
+++ b/flake.lock
@@ -266,6 +266,26 @@
         "type": "github"
       }
     },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688307440,
+        "narHash": "sha256-7PTjbN+/+b799YN7Tk2SS5Vh8A0L3gBo8hmB7Y0VXug=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "b06bab83bdf285ea0ae3c8e145a081eb95959047",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nixago": {
       "inputs": {
         "flake-utils": [
@@ -497,6 +517,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
         "nixt": "nixt",
         "pre-commit-hooks": "pre-commit-hooks",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,11 @@
       url = "github:cachix/devenv/latest";
       inputs.pre-commit-hooks.follows = "pre-commit-hooks";
     };
+
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -9,6 +9,7 @@ let
       devenvs = import ./src/devenvs.nix nixDirInputs cfg;
       nixt = import ./src/nixt.nix nixDirInputs cfg;
       passthrough = import ./src/passthrough.nix nixDirInputs cfg;
+      flkModules = import ./src/modules.nix nixDirInputs cfg;
       lib = import ./src/lib.nix nixDirInputs cfg;
 
       modules = [
@@ -18,6 +19,9 @@ let
         devenvs.applyDevenvShells
         devenvs.applyDevenvModules
         nixt.applyNixtTests
+        flkModules.applyDarwinModules
+        flkModules.applyNixosModules
+        flkModules.applyHomeManagerModules
         passthrough.applyPassthroughKeys
         lib.applyLib
       ];

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -8,6 +8,7 @@ let
       devshells = import ./src/devshells.nix nixDirInputs cfg;
       devenvs = import ./src/devenvs.nix nixDirInputs cfg;
       nixt = import ./src/nixt.nix nixDirInputs cfg;
+      passthrough = import ./src/passthrough.nix nixDirInputs cfg;
       lib = import ./src/lib.nix nixDirInputs cfg;
 
       modules = [
@@ -17,6 +18,7 @@ let
         devenvs.applyDevenvShells
         devenvs.applyDevenvModules
         nixt.applyNixtTests
+        passthrough.applyPassthroughKeys
         lib.applyLib
       ];
     in

--- a/nix/src/importer.nix
+++ b/nix/src/importer.nix
@@ -11,6 +11,9 @@
                                        , importNixtBlocks ? null
                                        , importDevenvShells ? null
                                        , importDevenvModules ? null
+                                       , importDarwinModules ? null
+                                       , importNixosModules ? null
+                                       , importHomeManagerModules ? null
                                        , importPreCommitConfig ? null
                                        , importPackages ? null
                                        , importOverlays ? null
@@ -134,15 +137,23 @@ let
   # _importDevShells is used to import the nixDir/devShells directory
   _importDevShells =
     pkgs: importDirFiles pkgs "withPkgs" (nixDir + "/devShells");
+  #
+  # _importDevenvShells is used to import the nixDir/devenvs directory
+  _importDevenvShells =
+    importDirFiles null "withNoPkgs" (nixDir + "/devenvs");
 
   # _importDevenvModules is used to import the nixDir/modules/devenv directory
   _importDevenvModules =
     importDirFiles null "withNoPkgs" (nixDir + "/modules/devenv");
 
-  # _importDevenvShells is used to import the nixDir/devenvs directory
-  _importDevenvShells =
-    importDirFiles null "withNoPkgs" (nixDir + "/devenvs");
+  _importDarwinModules =
+    importDirFiles null "withNoPkgs" (nixDir + "/modules/darwin");
 
+  _importNixosModules =
+    importDirFiles null "withNoPkgs" (nixDir + "/modules/nixos");
+
+  _importHomeManagerModules =
+    importDirFiles null "withNoPkgs" (nixDir + "/modules/home-manager");
 
   _importOverlays =
     importFile (nixDir + "/overlays.nix") inputs;
@@ -187,6 +198,24 @@ in
       _importDevenvModules
     else
       importDevenvModules;
+
+  importDarwinModules =
+    if importDarwinModules == null then
+      _importDarwinModules
+    else
+      importDarwinModules;
+
+  importNixosModules =
+    if importNixosModules == null then
+      _importNixosModules
+    else
+      importNixosModules;
+
+  importHomeManagerModules =
+    if importHomeManagerModules == null then
+      _importHomeManagerModules
+    else
+      importHomeManagerModules;
 
   importPreCommitConfig =
     if importPreCommitConfig == null then

--- a/nix/src/modules.nix
+++ b/nix/src/modules.nix
@@ -1,0 +1,41 @@
+nixDirInputs: { root
+              , dirName ? "nix"
+              , nixDir ? "${root}/${dirName}"
+              , pathExists ? builtins.pathExists
+              , ...
+              } @ buildFlakeCfg:
+
+let
+  utils = import ./utils.nix nixDirInputs buildFlakeCfg;
+  importer = import ./importer.nix nixDirInputs buildFlakeCfg;
+
+  inherit (utils) applyFlakeOutput;
+  inherit (importer) importDarwinModules importNixosModules importHomeManagerModules;
+
+  applyDarwinModules =
+    applyFlakeOutput
+      (pathExists "${nixDir}/modules/darwin")
+      {
+        darwinModules = importDarwinModules;
+      };
+
+  applyNixosModules =
+    applyFlakeOutput
+      (pathExists "${nixDir}/modules/nixos")
+      {
+        nixosModules = importNixosModules;
+      };
+
+  applyHomeManagerModules =
+    applyFlakeOutput
+      (pathExists "${nixDir}/modules/home-manager")
+      {
+        homeManagerModules = importHomeManagerModules;
+      };
+in
+{
+  inherit
+    applyDarwinModules
+    applyNixosModules
+    applyHomeManagerModules;
+}

--- a/nix/src/passthrough.nix
+++ b/nix/src/passthrough.nix
@@ -1,0 +1,34 @@
+{ nixpkgs, ... } @ nixDirInputs: buildFlakeCfg:
+
+let
+  inherit (nixpkgs) lib;
+
+  utils = import ./utils.nix nixDirInputs buildFlakeCfg;
+  inherit (utils) applyFlakeOutput;
+
+  # all these keys _do not_ rely on a system entry
+  passThroughKeys = [
+    "darwinConfigurations"
+    "nixosConfigurations"
+    "homeManagerConfigurations"
+  ];
+
+  applyPassthroughKeys =
+    let
+      step = acc: k:
+        if builtins.hasAttr k buildFlakeCfg then
+          acc // { "${k}" = buildFlakeCfg."${k}"; }
+        else
+          acc;
+    in
+    applyFlakeOutput
+      true # always
+      (final:
+        let
+          passthrough = builtins.foldl' step { } passThroughKeys;
+        in
+        lib.recursiveUpdate final passthrough);
+in
+{
+  inherit applyPassthroughKeys;
+}

--- a/nix/tests/nixt/modules_test.nix
+++ b/nix/tests/nixt/modules_test.nix
@@ -1,0 +1,169 @@
+{ self, nixpkgs, ... } @ nixDirInputs: { describe, it }:
+
+let
+  inherit (nixpkgs) lib;
+  system = "x86_64-linux";
+  systems = [ ];
+  mkBuildFlakeCfg =
+    { pathExists
+    , homeManagerModules ? [ ]
+    , darwinModules ? [ ]
+    , nixosModules ? [ ]
+    }:
+    let
+      pkgs = import nixpkgs { inherit system; };
+
+      inputs = {
+        inherit nixpkgs;
+        self = { };
+      };
+
+      # https://daiderd.com/nix-darwin/manual/index.html
+      mkDarwinModule = name:
+        ({ pkgs, ... }: {
+          networking.hostName = name;
+          homebrew.enable = true;
+        });
+
+      # https://search.nixos.org/options?
+      mkNixosModule = name:
+        ({ pkgs, ... }: {
+          networking.hostName = name;
+          services.mysql.enable = true;
+        });
+
+      # https://rycee.gitlab.io/home-manager/options.html
+      mkHomeManagerModule = name:
+        ({ pkgs, ... }: {
+          programs.emacs.enable = true;
+          home.username = name;
+        });
+
+
+      importDarwinModules =
+        builtins.foldl'
+          (acc: name: acc // { "${name}" = mkDarwinModule name; })
+          { }
+          darwinModules;
+
+      importNixosModules =
+        builtins.foldl'
+          (acc: name: acc // { "${name}" = mkNixosModule name; })
+          { }
+          nixosModules;
+
+      importHomeManagerModules =
+        builtins.foldl'
+          (acc: name: acc // { "${name}" = mkHomeManagerModule name; })
+          { }
+          homeManagerModules;
+
+    in
+    {
+      root = ./.;
+      inherit inputs systems;
+      # override importer functions to avoid relying on filesystem presence
+      inherit pathExists importDarwinModules importNixosModules importHomeManagerModules;
+    };
+
+  nixosSpecs = [
+    {
+      it = "generates a nixosModules output";
+      args = {
+        pathExists = lib.hasSuffix "nix/modules/nixos";
+        nixosModules = [ "one" "two" ];
+      };
+      assertion = flk:
+        lib.hasAttrByPath [ "nixosModules" "one" ] flk &&
+        lib.hasAttrByPath [ "nixosModules" "two" ] flk;
+    }
+  ];
+
+  darwinSpecs = [
+    {
+      it = "generates a darwinModules output";
+      args = {
+        pathExists = lib.hasSuffix "nix/modules/darwin";
+        darwinModules = [ "one" "two" ];
+      };
+      assertion = flk:
+        lib.hasAttrByPath [ "darwinModules" "one" ] flk &&
+        lib.hasAttrByPath [ "darwinModules" "two" ] flk;
+    }
+  ];
+
+  homeManagerSpecs = [
+    {
+      it = "generates a homeManagerModules output";
+      args = {
+        pathExists = lib.hasSuffix "nix/modules/home-manager";
+        homeManagerModules = [ "one" "two" ];
+      };
+      assertion = flk:
+        lib.hasAttrByPath [ "homeManagerModules" "one" ] flk &&
+        lib.hasAttrByPath [ "homeManagerModules" "two" ] flk;
+    }
+  ];
+
+in
+[
+  (describe "applyNixosModules"
+    (builtins.foldl'
+      (testsuites: spec:
+        testsuites ++
+        [
+          (it spec.it
+            (
+              let
+                buildFlakeCfg = mkBuildFlakeCfg {
+                  inherit (spec.args) nixosModules pathExists;
+                };
+                sut = import "${self}/nix/src/modules.nix" nixDirInputs buildFlakeCfg;
+                flk = sut.applyNixosModules { };
+              in
+              spec.assertion flk
+            ))
+        ])
+      [ ]
+      nixosSpecs))
+
+  (describe "applyDarwinModules"
+    (builtins.foldl'
+      (testsuites: spec:
+        testsuites ++
+        [
+          (it spec.it
+            (
+              let
+                buildFlakeCfg = mkBuildFlakeCfg {
+                  inherit (spec.args) darwinModules pathExists;
+                };
+                sut = import "${self}/nix/src/modules.nix" nixDirInputs buildFlakeCfg;
+                flk = sut.applyDarwinModules { };
+              in
+              spec.assertion flk
+            ))
+        ])
+      [ ]
+      darwinSpecs))
+
+  (describe "applyHomeManagerModules"
+    (builtins.foldl'
+      (testsuites: spec:
+        testsuites ++
+        [
+          (it spec.it
+            (
+              let
+                buildFlakeCfg = mkBuildFlakeCfg {
+                  inherit (spec.args) homeManagerModules pathExists;
+                };
+                sut = import "${self}/nix/src/modules.nix" nixDirInputs buildFlakeCfg;
+                flk = sut.applyHomeManagerModules { };
+              in
+              spec.assertion flk
+            ))
+        ])
+      [ ]
+      homeManagerSpecs))
+]

--- a/nix/tests/nixt/passthrough_tests.nix
+++ b/nix/tests/nixt/passthrough_tests.nix
@@ -1,0 +1,59 @@
+{ self, nixpkgs, nix-darwin, ... } @ nixDirInputs: { describe, it }:
+
+let
+  inherit (nixpkgs) lib;
+  systems = [ "x86_64-linux" "x86_64-darwin" ];
+
+  mkBuildFlakeCfg = extraKeys:
+    {
+      root = ./.;
+      inherit systems;
+      inputs = {
+        inherit nixpkgs nix-darwin;
+        self = { };
+      };
+    } // extraKeys;
+
+  specs = [
+    {
+      it = "passes through specific keys";
+      args = {
+        keys = {
+          nixosConfigurations = {
+            nixosMachine = nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              networking.hostName = "test";
+            };
+          };
+          darwinConfigurations = {
+            darwinMachine = nix-darwin.lib.darwinSystem {
+              system = "aarch64-darwin";
+            };
+          };
+        };
+      };
+      assertion = flk:
+        lib.hasAttrByPath [ "nixosConfigurations" "nixosMachine" ] flk &&
+        lib.hasAttrByPath [ "darwinConfigurations" "darwinMachine" ] flk;
+    }
+  ];
+in
+[
+  (describe "applyPassthrough"
+    (builtins.foldl'
+      (testsuites: spec:
+        testsuites ++
+        [
+          (it spec.it
+            (
+              let
+                buildFlakeCfg = mkBuildFlakeCfg spec.args.keys;
+                sut = import "${self}/nix/src/passthrough.nix" nixDirInputs buildFlakeCfg;
+                flk = sut.applyPassthroughKeys { };
+              in
+              spec.assertion flk
+            ))
+        ])
+      [ ]
+      specs))
+]


### PR DESCRIPTION
### Context

**As a developer** that maintains nixos, darwin and/or home-manager configurations in a flake
**I want to** be able to add modules through the file system (via `nix/modules/{nixos, darwin, home-manager}`)
And specify machine configurations via the keys `nixosConfigurations`, `darwinConfigurations` and `homeManagerConfigurations` keys
**So that** I can make use of `nixDir` for all my use cases