### PR TITLE
fix: all package shells support

### DIFF
--- a/nix/src/packages.nix
+++ b/nix/src/packages.nix
@@ -89,7 +89,13 @@ let
               # shellPkgs are all the devShells derivations, these allow us to
               # cache shells the same way we do packages.
               lib.concatMapAttrs
-                (name: shell: { "${name}-shell" = shell.inputDerivation; })
+                (name: shell:
+                  # skip devenv shells. They must be skipped given they are
+                  # impure and caching them wouldn't make much sense.
+                  if lib.hasPrefix "devenv-" shell.name then
+                    { }
+                  else
+                    { "${name}-shell" = shell.inputDerivation; })
                 inputs.self.devShells.${pkgs.system};
 
             result =

--- a/nix/src/packages.nix
+++ b/nix/src/packages.nix
@@ -99,7 +99,8 @@ let
                 resultPkgs // {
                   all = pkgs.symlinkJoin {
                     name = "all";
-                    paths = lib.attrValues (resultPkgs // shellPkgs);
+                    buildInputs = lib.attrValues shellPkgs;
+                    paths = lib.attrValues resultPkgs;
                   };
                 }
               else


### PR DESCRIPTION
This PR includes two fixes:

1) The `all` package relies on symlinkJoin. We used the `path` attribute to join all packages, but this doesn't work with devShells. 

2) Exclude `devShells` that are created with `devenv`, these are impure by default and it makes no sense to cache them as they are host dependent