### PR TITLE
fix: lib utility should receive client flake inputs

### DIFF
--- a/nix/src/lib.nix
+++ b/nix/src/lib.nix
@@ -1,4 +1,5 @@
 nixDirInputs: { root
+              , inputs
               , dirName ? "nix"
               , pathExists ? builtins.pathExists
               , importFile ? (path: import path)
@@ -31,7 +32,7 @@ in
           let
             userLib =
               if pathExists "${nixDir}/lib.nix" then
-                importFile "${nixDir}/lib.nix" nixDirInputs
+                importFile "${nixDir}/lib.nix" inputs
               else
                 { };
           in


### PR DESCRIPTION
When using lib on a client flake, the user is expecting to use their inputs rather than nixDir inputs.