### PR TITLE
Discover .nix files at all directory levels

### DIFF
--- a/src/importer.nix
+++ b/src/importer.nix
@@ -102,7 +102,10 @@ let
     else
       result.discovered;
 
-  # discoverDirsWithFlakeOutputs recursively finds directories containing default.nix files.
+  # discoverFlakeOutputs recursively finds all Nix entries in a directory tree:
+  # - Directories containing default.nix (leaf directories)
+  # - Standalone .nix files at any level
+  #
   # Works for all output types: packages, modules, configurations, devshells, etc.
   #
   # Arguments:
@@ -117,7 +120,8 @@ let
   #
   # Leaf rule: directory with default.nix is a leaf (entry found, don't recurse deeper).
   # Conflict check: errors if both foo/default.nix and foo.nix exist at same level.
-  discoverDirsWithFlakeOutputs =
+  # File rule: .nix files are discovered at any level with their basename as name.
+  discoverFlakeOutputs =
     {
       outputRoot,
       currentPath,
@@ -212,51 +216,53 @@ let
           }
         # Organizational directory - recurse
         else
-          discoverDirsWithFlakeOutputs {
+          discoverFlakeOutputs {
             inherit outputRoot;
             currentPath = dirPath;
             pathFromRoot = newPathFromRoot;
             depth = depth + 1;
           };
 
-      results = map processDir visibleDirs;
+      dirResults = map processDir visibleDirs;
+      discoveredFromDirs = builtins.concatLists (map (r: r.discovered) dirResults);
+      ignoredFromDirs = builtins.concatLists (map (r: r.ignored) dirResults);
+
+      # Collect .nix files at current level, excluding those that conflict with directories
+      discoveredDirNames = map (d: d.name) discoveredFromDirs;
+      localNixFiles = builtins.filter (f: !builtins.elem (lib.removeSuffix ".nix" f) discoveredDirNames) (
+        nixFiles currentPath
+      );
+      fileEntries = map (fileName: {
+        name = lib.removeSuffix ".nix" fileName;
+        pathFromRoot = if pathFromRoot == "" then fileName else "${pathFromRoot}/${fileName}";
+      }) localNixFiles;
     in
     {
-      discovered = builtins.concatLists (map (r: r.discovered) results);
-      ignored = builtins.concatLists (map (r: r.ignored) results);
+      discovered = discoveredFromDirs ++ fileEntries;
+      ignored = ignoredFromDirs;
     };
 
-  # nixSubDirNames traverses subdirectories recursively looking for default.nix files.
-  # Returns list of { name, pathFromRoot } records for directories containing default.nix.
-  # In strict mode, throws if any directories were ignored.
-  nixSubDirNames =
+  # discoverOutputs finds all Nix entries (directories with default.nix and .nix files).
+  # Returns list of { name, pathFromRoot } records.
+  # In strict mode, throws if any entries were ignored.
+  discoverOutputs =
     path:
-    validateDiscovery path (discoverDirsWithFlakeOutputs {
+    validateDiscovery path (discoverFlakeOutputs {
       outputRoot = path;
       currentPath = path;
     });
 
   # mkImportDir creates an import function that discovers and imports files from a directory.
   # This is the core building block - takes a single-file import function and applies it
-  # to all discovered files/directories.
+  # to all discovered entries (directories with default.nix and standalone .nix files).
   mkImportDir =
     importFn: path:
-    let
-      fromDirs = builtins.listToAttrs (
-        map (entry: {
-          name = entry.name;
-          value = importFn "${path}/${entry.pathFromRoot}";
-        }) (nixSubDirNames path)
-      );
-
-      fromFiles = builtins.listToAttrs (
-        map (fileName: {
-          name = lib.removeSuffix ".nix" fileName;
-          value = importFn "${path}/${fileName}";
-        }) (nixFiles path)
-      );
-    in
-    fromDirs // fromFiles;
+    builtins.listToAttrs (
+      map (entry: {
+        name = entry.name;
+        value = importFn "${path}/${entry.pathFromRoot}";
+      }) (discoverOutputs path)
+    );
 
   # importByStrategy creates an import function based on strategy and withInputs flag.
   # This single function replaces 18 import* functions from the old importer.

--- a/tests/nested-discovery/fixtures/nested-files/category/nested-dir/default.nix
+++ b/tests/nested-discovery/fixtures/nested-files/category/nested-dir/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.writeText "nested-dir" "nested dir with default.nix"

--- a/tests/nested-discovery/fixtures/nested-files/category/nested-file.nix
+++ b/tests/nested-discovery/fixtures/nested-files/category/nested-file.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.writeText "nested-file" "nested .nix file in category"

--- a/tests/nested-discovery/fixtures/nested-files/root-file.nix
+++ b/tests/nested-discovery/fixtures/nested-files/root-file.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.writeText "root-file" "root level .nix file"

--- a/tests/nested-discovery/tests.nix
+++ b/tests/nested-discovery/tests.nix
@@ -39,6 +39,7 @@ let
   terminalPath = ./fixtures/terminal;
   fileBlockingPath = ./fixtures/file-blocking;
   symlinksPath = ./fixtures/symlinks;
+  nestedFilesPath = ./fixtures/nested-files;
 in
 {
   tests = [
@@ -273,6 +274,39 @@ in
           result = symlinkImporter.importPackages symlinksPath;
         in
         result ? real-pkg;
+    }
+
+    {
+      name = "nested-files: discovers .nix file at root level";
+      type = "unit";
+      expected = true;
+      actual =
+        let
+          result = importer.importPackages nestedFilesPath;
+        in
+        result ? root-file;
+    }
+
+    {
+      name = "nested-files: discovers .nix file inside organizational directory";
+      type = "unit";
+      expected = true;
+      actual =
+        let
+          result = importer.importPackages nestedFilesPath;
+        in
+        result ? nested-file;
+    }
+
+    {
+      name = "nested-files: discovers directory with default.nix inside organizational directory";
+      type = "unit";
+      expected = true;
+      actual =
+        let
+          result = importer.importPackages nestedFilesPath;
+        in
+        result ? nested-dir;
     }
   ];
 }


### PR DESCRIPTION
## Summary

- Unifies discovery into a single recursive mechanism (`discoverFlakeOutputs`)
- Finds both directory entries (with `default.nix`) and standalone `.nix` files at every level
- Removes redundant root-level file discovery from `mkImportDir`

Previously, `.nix` files were only discovered at the root level of output directories. Files inside organizational subdirectories like `packages/utils/helper.nix` were silently ignored.

This enables patterns like:

```
packages/
  utils/
    helper.nix      # now discovered as "helper"
    tool/
      default.nix   # already worked as "tool"
```

## Test plan

- [x] Added new test fixture `nested-files/` with `.nix` files at multiple levels
- [x] Added 3 new tests covering root-level files, nested files, and nested directories
- [x] All 84 unit tests pass
- [x] All 11 integration tests pass