### PR TITLE
docs: document nested file discovery and use GitHub admonitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ All notable changes to this project will be documented in this file.
 ### Documentation
 
 - Add CLAUDE.md with test instructions
+- Document .nix files in organizational subdirectories
 
 ### Features
 
 - Add recursive nested directory discovery
+- Discover .nix files at all directory levels (not just root)
 - Add file blocking rule for directory traversal
 - Add strictDiscovery option for ignored package detection
 - Add followSymlinks option for symlink directory traversal

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Key options:
 - `installFlakeOverlay` - Make packages available in `pkgs` across all your outputs
 - `filterUnsupportedSystems` - Filter packages by `meta.platforms` (default: `true`)
   - Note: Automatically disabled when `generateAllPackage = true` to avoid infinite recursion
+- `strictDiscovery` - Error when directories are ignored during discovery (default: `false`)
+  - Useful for catching organizational issues like exceeding max nesting depth
+- `followSymlinks` - Follow symlinks during directory discovery (default: `false`)
 
 See [example flake.nix](./example/myproj/flake.nix) for all options.
 

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -132,7 +132,8 @@ pkgs.mkShell {
 
 **Result**: Available via `nix develop`
 
-**Note**: DevShell names must be unique across both `devshells/` and `devenvs/` since devenv creates devShells internally.
+> [!NOTE]
+> DevShell names must be unique across both `devshells/` and `devenvs/` since devenv creates devShells internally.
 
 ### devenvs/
 
@@ -209,7 +210,8 @@ pkgs.mkShell {
 
 **Signature**: Standard devenv module
 
-**Note**: These can be automatically imported into all devenvs using the option
+> [!NOTE]
+> These can be automatically imported into all devenvs using the option
 `installAllDevenvModules`
 
 ### configurations/nixos/
@@ -241,9 +243,9 @@ pkgs.mkShell {
 
 ## File vs Directory Naming
 
-You can define items in two ways:
+You can define items in three ways:
 
-### Single File
+### Single File at Root
 
 ```
 packages/
@@ -251,6 +253,20 @@ packages/
 ```
 
 **When to use**: Simple, self-contained definitions
+
+**Output**: `packages.<system>.hello`
+
+### Single File in Organizational Directory
+
+```
+packages/
+└── utils/
+    └── helper.nix
+```
+
+**When to use**: Grouping related packages without creating separate directories for each
+
+**Output**: `packages.<system>.helper` (organizational directories don't affect the name)
 
 ### Directory with default.nix
 
@@ -265,7 +281,21 @@ packages/
 
 **When to use**: Complex definitions needing multiple files
 
-**Both create the same output**: `packages.<system>.hello`
+**Output**: `packages.<system>.hello`
+
+You can combine these patterns:
+
+```
+packages/
+├── simple.nix                    # → packages.<system>.simple
+├── utils/
+│   ├── helper.nix                # → packages.<system>.helper
+│   └── formatter/
+│       └── default.nix           # → packages.<system>.formatter
+└── tools/
+    └── cli/
+        └── default.nix           # → packages.<system>.cli
+```
 
 ## File Naming Conventions
 
@@ -449,8 +479,11 @@ my-project/
 └── nix/
     ├── packages/
     │   ├── cli.nix
+    │   ├── utils/
+    │   │   ├── helper.nix        # Organized in subdirectory
+    │   │   └── formatter.nix
     │   └── server/
-    │       ├── default.nix
+    │       ├── default.nix       # Complex package with multiple files
     │       └── config.yaml
     ├── devshells/
     │   ├── default.nix
@@ -514,7 +547,14 @@ platform/
 **Solution**: Check your filename:
 - `my-package.nix` → `my-package` (not `myPackage`)
 - Remove the `.nix` extension from the attribute name
-- Directory names don't matter, only the final file/directory name
+- Organizational directory names don't affect the output name
+
+Examples:
+```
+packages/hello-world.nix        → packages.<system>.hello-world
+packages/utils/helper.nix       → packages.<system>.helper
+packages/tools/cli/default.nix  → packages.<system>.cli
+```
 
 ### Import Errors
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ Edit your `flake.nix`:
 }
 ```
 
-> **Warning**
+> [!WARNING]
 > Remember to run `git add flake.nix nix` before building. Nix flakes only see git-tracked files.
 
 ## Your First Package
@@ -118,6 +118,11 @@ nixDir follows these conventions:
 |--------------|---------|
 | `nix/packages/NAME.nix` | `packages.<system>.NAME` |
 | `nix/packages/NAME/default.nix` | `packages.<system>.NAME` |
+| `nix/packages/category/NAME.nix` | `packages.<system>.NAME` |
+| `nix/packages/category/NAME/default.nix` | `packages.<system>.NAME` |
+
+> [!NOTE]
+> Organizational subdirectories (like `category/`) don't affect the output name.
 
 nixDir automatically:
 1. Scanned the `nix/packages/` directory

--- a/docs/with-inputs.md
+++ b/docs/with-inputs.md
@@ -256,9 +256,10 @@ inputs: { pkgs, ... }:
 }
 ```
 
-> ![IMPORTANT] DevShell and DevEnv names must be unique across both types since devenv
-> creates devShells internally. You cannot have a devShell named "default" and a devenv
-> named "default" - nixDir will detect this conflict and throw an error.
+> [!IMPORTANT]
+> DevShell and DevEnv names must be unique across both types since devenv creates devShells
+> internally. You cannot have a devShell named "default" and a devenv named "default" -
+> nixDir will detect this conflict and throw an error.
 
 ## Conflict Detection
 


### PR DESCRIPTION
## Summary

- Document .nix files in organizational subdirectories (new feature from #20)
- Add examples showing nested file patterns in directory-structure.md
- Update getting-started.md convention table to include nested patterns
- Document `strictDiscovery` and `followSymlinks` options in README
- Convert all notes/warnings to GitHub admonition format (`> [!NOTE]`, etc.)
- Fix incorrect admonition syntax in with-inputs.md (`> ![IMPORTANT]` → `> [!IMPORTANT]`)

## Test plan

- [x] Documentation renders correctly on GitHub
- [x] All admonitions use correct GitHub syntax